### PR TITLE
Liberal execjs requirement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "http://rubygems.org"
 # Example:
 #   gem "activesupport", ">= 2.3.5"
 
-gem "execjs", "~> 0.1.0"
+gem "execjs"
 gem "json"
 
 # Add dependencies to develop your gem here.


### PR DESCRIPTION
ExecJS 0.2 is the latest version now. I'd recommend just floating with a liberal requirement. Otherwise people using uglifier are going to be stuck with old versions of ExecJS.
