### PR TITLE
The uglifier.rb file wasn't requiring json

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "http://rubygems.org"
 #   gem "activesupport", ">= 2.3.5"
 
 gem "execjs"
-gem "json"
+gem "multi_json"
 
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.

--- a/lib/uglifier.rb
+++ b/lib/uglifier.rb
@@ -1,8 +1,9 @@
 require "execjs"
-require "json"
+require "multi_json"
 
 class Uglifier
   Error = ExecJS::Error
+  # MultiJson.engine = :json_gem
 
   DEFAULTS = {
     :mangle => true, # Mangle variables names
@@ -38,7 +39,7 @@ class Uglifier
 
     js = []
     js << "var result = '';"
-    js << "var source = #{source.to_json};"
+    js << "var source = #{MultiJson.encode(source)};"
     js << "var ast = UglifyJS.parser.parse(source);"
 
     if @options[:copyright]
@@ -52,18 +53,18 @@ class Uglifier
     end
 
     if @options[:mangle]
-      js << "ast = UglifyJS.uglify.ast_mangle(ast, #{mangle_options.to_json});"
+      js << "ast = UglifyJS.uglify.ast_mangle(ast, #{MultiJson.encode(mangle_options)});"
     end
 
     if @options[:squeeze]
-      js << "ast = UglifyJS.uglify.ast_squeeze(ast, #{squeeze_options.to_json});"
+      js << "ast = UglifyJS.uglify.ast_squeeze(ast, #{MultiJson.encode(squeeze_options)});"
     end
 
     if @options[:unsafe]
       js << "ast = UglifyJS.uglify.ast_squeeze_more(ast);"
     end
 
-    js << "result += UglifyJS.uglify.gen_code(ast, #{gen_code_options.to_json});"
+    js << "result += UglifyJS.uglify.gen_code(ast, #{MultiJson.encode(gen_code_options)});"
     js << "return result;"
 
     @context.exec js.join("\n")

--- a/uglifier.gemspec
+++ b/uglifier.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Ville Lautanala"]
-  s.date = %q{2011-04-27}
+  s.date = %q{2011-05-05}
   s.email = %q{lautis@gmail.com}
   s.extra_rdoc_files = [
     "LICENSE.txt",
@@ -29,11 +29,14 @@ Gem::Specification.new do |s|
     "lib/uglify.js",
     "spec/spec_helper.rb",
     "spec/uglifier_spec.rb",
-    "uglifier.gemspec"
+    "uglifier.gemspec",
+    "vendor/uglifyjs/lib/parse-js.js",
+    "vendor/uglifyjs/lib/process.js",
+    "vendor/uglifyjs/lib/squeeze-more.js"
   ]
   s.homepage = %q{http://github.com/lautis/uglifier}
   s.require_paths = ["lib"]
-  s.rubygems_version = %q{1.7.2}
+  s.rubygems_version = %q{1.5.0}
   s.summary = %q{Ruby wrapper for UglifyJS JavaScript compressor}
   s.test_files = [
     "spec/spec_helper.rb",
@@ -45,14 +48,14 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<execjs>, [">= 0"])
-      s.add_runtime_dependency(%q<json>, [">= 0"])
+      s.add_runtime_dependency(%q<multi_json>, [">= 0"])
       s.add_development_dependency(%q<rspec>, ["~> 2.5.0"])
       s.add_development_dependency(%q<bundler>, ["~> 1.0.0"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.5.0"])
       s.add_development_dependency(%q<rcov>, [">= 0"])
     else
       s.add_dependency(%q<execjs>, [">= 0"])
-      s.add_dependency(%q<json>, [">= 0"])
+      s.add_dependency(%q<multi_json>, [">= 0"])
       s.add_dependency(%q<rspec>, ["~> 2.5.0"])
       s.add_dependency(%q<bundler>, ["~> 1.0.0"])
       s.add_dependency(%q<jeweler>, ["~> 1.5.0"])
@@ -60,7 +63,7 @@ Gem::Specification.new do |s|
     end
   else
     s.add_dependency(%q<execjs>, [">= 0"])
-    s.add_dependency(%q<json>, [">= 0"])
+    s.add_dependency(%q<multi_json>, [">= 0"])
     s.add_dependency(%q<rspec>, ["~> 2.5.0"])
     s.add_dependency(%q<bundler>, ["~> 1.0.0"])
     s.add_dependency(%q<jeweler>, ["~> 1.5.0"])


### PR DESCRIPTION
Even though most people will be using this in a rails environment where you'd never see this, uglifier.rb wasn't requiring the json gem and erroring out when you did a require 'uglifier'

Before:

require 'uglifier'
Uglifier.compile("zomg")

NoMethodError: undefined method `to_json' for "zomg":String
    from /Users/matthewkirk/.rvm/gems/ruby-1.9.1-p378/gems/uglifier-0.5.1/lib/uglifier.rb:40:in`compile'
    from /Users/matthewkirk/.rvm/gems/ruby-1.9.1-p378/gems/uglifier-0.5.1/lib/uglifier.rb:26:in `compile'
    from (irb):2
    from /Users/matthewkirk/.rvm/rubies/ruby-1.9.1-p378/bin/irb:17:in`<main>'

After:
require 'uglifier'
Uglifier.compile("zomg") => "zomg"
