### PR TITLE
removeing files from gemspec file list while bundler tells not valid gemspec

### DIFF
--- a/uglifier.gemspec
+++ b/uglifier.gemspec
@@ -29,10 +29,7 @@ Gem::Specification.new do |s|
     "lib/uglify.js",
     "spec/spec_helper.rb",
     "spec/uglifier_spec.rb",
-    "uglifier.gemspec",
-    "vendor/uglifyjs/lib/parse-js.js",
-    "vendor/uglifyjs/lib/process.js",
-    "vendor/uglifyjs/lib/squeeze-more.js"
+    "uglifier.gemspec"
   ]
   s.homepage = %q{http://github.com/lautis/uglifier}
   s.require_paths = ["lib"]


### PR DESCRIPTION
Gemfile
`gem 'uglifier',             :git => 'git://github.com/lautis/uglifier.git'`

bundle install output

```
Using uglifier (0.5.3) from git://github.com/lautis/uglifier.git (at master) 
uglifier at /Users/captainhagbard/.rvm/gems/ruby-1.9.2-p180/bundler/gems/uglifier-dec44597a864 did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  ["vendor/uglifyjs/lib/parse-js.js", "vendor/uglifyjs/lib/process.js", "vendor/uglifyjs/lib/squeeze-more.js"] are not files
```

fix: removing the not existing files from gemspec file list
