### PR TITLE
Run tests against bundled JavaScript file

### DIFF
--- a/spec/uglifier_spec.rb
+++ b/spec/uglifier_spec.rb
@@ -3,7 +3,7 @@ require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
 describe "Uglifier" do
   it "minifies JS" do
-    source = File.open("vendor/uglifyjs/lib/process.js", "r:UTF-8").read
+    source = File.open("lib/uglify.js", "r:UTF-8").read
     minified = Uglifier.new.compile(source)
     minified.length.should < source.length
     lambda {
@@ -122,13 +122,13 @@ describe "Uglifier" do
   describe "Input Formats" do
     it "handles strings" do
       lambda {
-        Uglifier.new.compile(File.open("vendor/uglifyjs/lib/process.js", "r:UTF-8").read).should_not be_empty
+        Uglifier.new.compile(File.open("lib/uglify.js", "r:UTF-8").read).should_not be_empty
       }.should_not raise_error
     end
 
     it "handles files" do
       lambda {
-        Uglifier.new.compile(File.open("vendor/uglifyjs/lib/process.js", "r:UTF-8")).should_not be_empty
+        Uglifier.new.compile(File.open("lib/uglify.js", "r:UTF-8")).should_not be_empty
       }.should_not raise_error
     end
   end


### PR DESCRIPTION
This let's people run the tests without pulling the UglifyJS submodule,
what is useful e.g. when you obtained the sources from rubygems.org and
not from the git repository.
