### PR TITLE
Add license to gemspec

### DIFF
--- a/uglifier.gemspec
+++ b/uglifier.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Ville Lautanala"]
+  s.license = "MIT"
   s.date = "2012-09-02"
   s.email = "lautis@gmail.com"
   s.extra_rdoc_files = [


### PR DESCRIPTION
Prior to this commit, the gemspec did not include the license, which
means that one can't use the rubygems API to automatically determine
licensing of vendored gems. This commit adds the licensing to the
gemspec.
