### PR TITLE
Remove multi_json dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Any contributions to Uglifier are welcome, whether they are feedback, bug report
 
 ## Reporting issues
 
-Uglifier uses the [GitHub issue tracker](https://github.com/lautis/uglifier/issues) to track bugs and features. Before submitting a bug report or feature request, check to make sure it hasn't already been submitted. You can indicate support for an existing issuse by voting it up. When submitting a bug report, please include a Gist that includes a stack trace and any details that may be necessary to reproduce the bug, including your gem version, Ruby version, **MultiJSON engine** and **ExecJS runtime**. Ideally, a bug report should include a pull request with failing specs.
+Uglifier uses the [GitHub issue tracker](https://github.com/lautis/uglifier/issues) to track bugs and features. Before submitting a bug report or feature request, check to make sure it hasn't already been submitted. You can indicate support for an existing issuse by voting it up. When submitting a bug report, please include a Gist that includes a stack trace and any details that may be necessary to reproduce the bug, including your gem version, Ruby version, and **ExecJS runtime**. Ideally, a bug report should include a pull request with failing specs.
 
 ## Contributing to uglifier
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
-gem "execjs", ">=0.3.0"
-gem "multi_json", "~> 1.0", ">= 1.0.2"
+gem "execjs", ">= 0.3.0"
+gem "json", ">= 1.8.0"
 
 # Depend on defined ExecJS runtime
 execjs_runtimes = {
@@ -13,9 +13,6 @@ execjs_runtimes = {
 if ENV["EXECJS_RUNTIME"] && execjs_runtimes[ENV["EXECJS_RUNTIME"]]
   gem execjs_runtimes[ENV["EXECJS_RUNTIME"]], :group => :development
 end
-
-# Engine
-gem ENV["MULTI_JSON_ENGINE"], :group => :development if ENV["MULTI_JSON_ENGINE"]
 
 group :development do
   gem "rspec", "~> 2.7"

--- a/lib/uglifier.rb
+++ b/lib/uglifier.rb
@@ -1,7 +1,7 @@
 # encoding: UTF-8
 
 require "execjs"
-require "multi_json"
+require "json"
 
 class Uglifier
   Error = ExecJS::Error
@@ -257,15 +257,8 @@ class Uglifier
     end
   end
 
-  # MultiJson API detection
-  if MultiJson.respond_to? :dump
-    def json_encode(obj)
-      MultiJson.dump(obj)
-    end
-  else
-    def json_encode(obj)
-      MultiJson.encode(obj)
-    end
+  def json_encode(obj)
+    JSON.dump(obj)
   end
 
   def encode_regexp(regexp)

--- a/uglifier.gemspec
+++ b/uglifier.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<execjs>, [">= 0.3.0"])
-      s.add_runtime_dependency(%q<multi_json>, [">= 1.0.2", "~> 1.0"])
+      s.add_runtime_dependency(%q<json>, [">= 1.8.0"])
       s.add_development_dependency(%q<rspec>, ["~> 2.7"])
       s.add_development_dependency(%q<bundler>, ["~> 1.0"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.8.3"])
@@ -55,7 +55,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<source_map>, [">= 0"])
     else
       s.add_dependency(%q<execjs>, [">= 0.3.0"])
-      s.add_dependency(%q<multi_json>, [">= 1.0.2", "~> 1.0"])
+      s.add_dependency(%q<json>, [">= 1.8.0"])
       s.add_dependency(%q<rspec>, ["~> 2.7"])
       s.add_dependency(%q<bundler>, ["~> 1.0"])
       s.add_dependency(%q<jeweler>, ["~> 1.8.3"])
@@ -64,7 +64,7 @@ Gem::Specification.new do |s|
     end
   else
     s.add_dependency(%q<execjs>, [">= 0.3.0"])
-    s.add_dependency(%q<multi_json>, [">= 1.0.2", "~> 1.0"])
+    s.add_dependency(%q<json>, [">= 1.8.0"])
     s.add_dependency(%q<rspec>, ["~> 2.7"])
     s.add_dependency(%q<bundler>, ["~> 1.0"])
     s.add_dependency(%q<jeweler>, ["~> 1.8.3"])


### PR DESCRIPTION
As you are probably aware, [Ruby 1.8 will stop being updated—even for critical security issues—past June](http://www.ruby-lang.org/en/news/2011/10/06/plans-for-1-8-7/). This patch changes the minimum Ruby version to 1.9, as has [already been done in the forthcoming version of Rails](https://github.com/rails/rails/commit/e883c06a4f924cc4ba74efe4dad36394fad26fa0), currently in release candidate.

Since Ruby 1.9 includes `json` in the standard library, `multi_json` is no longer necessary. I am a longtime maintainer of `multi_json` but [will stop supporting the library in June](https://github.com/intridea/multi_json/pull/113#issuecomment-17668823).

This patch replaces `multi_json` with stdlib `json`. It will use the `json` gem if a newer version is available.

I have already submitted [a similar pull request to `execjs`](https://github.com/sstephenson/execjs/pull/126) and will shortly be submitting pull requests to `sprockets` and `rails` itself, so `multi_json` need not be a dependency of Rails 4 applications. This should have the effect of making JSON parsing and generation somewhat faster by removing an abstraction layer that is no longer necessary.
