### PR TITLE
Clarify configuration variable comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Available options and their defaults are
   :source_root => nil,          # The URL of the directory which contains :source_filename
   :output_filename => nil,      # The filename or URL where the minified output can be found
   :input_source_map => nil,     # The contents of the source map describing the input
-  :screw_ie8 => false           # Generate safe code for IE8
+  :screw_ie8 => false           # Don't bother to generate safe code for IE8
 }
 ```
 


### PR DESCRIPTION
`screw_ie8: true` turns off changes that make output safe for IE8.

To match the style of other boolean setting comments, say what the screw_ie8 setting does when its value is true.
