### PR TITLE
Update :copyright comment preservation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Available options and their defaults are
 {
   :output => {
     :ascii_only => true,        # Escape non-ASCII characters
-    :comments => :copyright,    # Preserve comments (:all, :jsdoc, :copyright, :none)
+    :comments => :copyright,    # Preserve comments (:all, :jsdoc, :copyright, :none, Regexp (see below))
     :inline_script => false,    # Escape occurrences of </script in strings
     :quote_keys => false,       # Quote keys in object literals
     :max_line_len => 32 * 1024, # Maximum line length in minified code
@@ -100,6 +100,18 @@ Available options and their defaults are
   :source_url => false          # Url to original source to be appended in minified source
 }
 ```
+
+When passing a regular expression to the output => comments option, be sure to pass a valid Ruby Regexp.
+The beginning and ending of comments are removed and cannot be matched (/*, */, //). For example:
+When matching
+
+```
+/*!
+ * comment
+ */
+```
+
+use `Uglifier.new(output: {comments: /^!/})`.
 
 ## Development
 

--- a/lib/uglifier.rb
+++ b/lib/uglifier.rb
@@ -237,7 +237,7 @@ class Uglifier
     when :jsdoc
       "jsdoc"
     when :copyright
-      encode_regexp(/Copyright/i)
+      encode_regexp(/(^!)|Copyright/i)
     when Regexp
       encode_regexp(comment_setting)
     else

--- a/spec/uglifier_spec.rb
+++ b/spec/uglifier_spec.rb
@@ -60,8 +60,10 @@ describe "Uglifier" do
         /* @preserve Copyright Notice */
         /* (c) 2011 */
         // INCLUDED
+        //! BANG
         function identity(p) { return p; }
         /* Another Copyright */
+        /*! Another Bang */
         function add(a, b) { return a + b; }
       EOS
     end
@@ -77,6 +79,11 @@ describe "Uglifier" do
       it "preserves comments with string Copyright" do
         expect(subject).to match(/Copyright Notice/)
         expect(subject).to match(/Another Copyright/)
+      end
+
+      it "preserves comments that start with a bang (!)" do
+        expect(subject).to match(/! BANG/)
+        expect(subject).to match(/! Another Bang/)
       end
 
       it "ignores other comments" do

--- a/spec/uglifier_spec.rb
+++ b/spec/uglifier_spec.rb
@@ -64,6 +64,7 @@ describe "Uglifier" do
         function identity(p) { return p; }
         /* Another Copyright */
         /*! Another Bang */
+        // A comment!
         function add(a, b) { return a + b; }
       EOS
     end
@@ -88,6 +89,7 @@ describe "Uglifier" do
 
       it "ignores other comments" do
         expect(subject).not_to match(/INCLUDED/)
+        expect(subject).not_to match(/A comment!/)
       end
     end
 


### PR DESCRIPTION
I think updating the comment preservation's :copyright option to also include comments that start with bangs will help consumers avoid accidentally stripping out desired comments.

I also updated the README to explain how a regex should be passed. I had to go through the source code to determine that I needed to pass a Ruby Regexp as opposed to a string that would be used by UglifyJS and that the beginning and end of the comment would be removed before the regex would be applied.