### PR TITLE
Update CONTRIBUTING.md for "rake js".

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ After that, UglifyJS and source-map are checked out under `vendor/uglifyjs` and 
 
 Use Git commands (e.g. git checkout master) to change the included version. You can even write custom code to yourself. After changing the dependencies, compile new version of the bundled JS file using
 
-    rake js
+    bundle exec rake js
 
 After this, the new JS is used in your development version.
 


### PR DESCRIPTION
I want to update a little bit of https://github.com/lautis/uglifier/blob/master/CONTRIBUTING.md
as I got an error following the document.

```
$ bundle install --path vendor/bundle

$ git submodule update --init

$ rake js
rake aborted!
LoadError: cannot load such file -- rspec/core/rake_task
/home/jaruga/git/uglifier/Rakefile:4:in `<top (required)>'
(See full trace by running task with --trace)
```

Could you merge my patch?
Thanks.
