### PR TITLE
Remove the line to set to window object from "rake js".

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,6 @@ task :js do
   end
 
   source = ""
-  source << "window = this;"
   source << File.read("vendor/source-map/dist/source-map.js")
   source << "MOZ_SourceMap = sourceMap;"
   source << `./vendor/uglifyjs/bin/uglifyjs --self --comments /Copyright/`

--- a/lib/uglify.js
+++ b/lib/uglify.js
@@ -1,4 +1,4 @@
-window = this;(function webpackUniversalModuleDefinition(root, factory) {
+(function webpackUniversalModuleDefinition(root, factory) {
 	if(typeof exports === 'object' && typeof module === 'object')
 		module.exports = factory();
 	else if(typeof define === 'function' && define.amd)


### PR DESCRIPTION
Could you tell me why "window = this;" in the Rakefile is necessary?
I rebuilt lib/uglify.js, and checked the test suite was passed.

```
bundle exec rake js
bundle exec rake
```
