### PR TITLE
Add ruby-head to Travis as allow_failures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
   - 2.2.6
   - 2.3.3
   - 2.4.1
+  - ruby-head
   - jruby-19mode
   - jruby-9.1.8.0
 git:
@@ -27,3 +28,5 @@ matrix:
     - rvm: 2.4.1
       gemfile: gemfiles/alaska
       env: ALASKA=1
+    - rvm: ruby-head
+  fast_finish: true


### PR DESCRIPTION
Hello @lautis 

I want to add `ruby-head` as `allow_failures` in `.travis.yml`.
I think this is useful.
Because we can prepare before next version Ruby 2.5 release.
Though it might not be useful until the actual preview release.
We can support the next version as faster.
  
We can see this kind of logic in `rails`, `rspec` and `cucumber` and etc.

https://github.com/rails/rails/blob/master/.travis.yml
https://github.com/rspec/rspec-core/blob/master/.travis.yml
https://github.com/cucumber/cucumber-ruby/blob/master/.travis.yml

`fast_finish` is to get the Travis result as faster without waiting the result of the `allow_failures` items.
See https://blog.travis-ci.com/2013-11-27-fast-finishing-builds/

Is it possible to add it?

Thanks.