### PR TITLE
Add SemVer compatibility badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ UglifyJS currently is extensively tested with ES5, but also includes experimenta
 More stable alternatives for working with ES6 code is to first transpile to ES5 with e.g. [babel-transpiler](https://github.com/babel/ruby-babel-transpiler) or using [Closure Compiler](https://github.com/documentcloud/closure-compiler) to directly minify ES6 code.
 
 [![Build Status](https://travis-ci.org/lautis/uglifier.svg?branch=master)](https://travis-ci.org/lautis/uglifier)
+[![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=uglifier&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=uglifier&package-manager=bundler&version-scheme=semver)
 
 ## ES6 / ES2015+ / Harmony mode
 


### PR DESCRIPTION
Adds a SemVer compatibility badge that displays the percentage of CI runs that pass when updating `uglifier` between SemVer compatible versions. Data comes from Dependabot (disclosure: I built it).

Here's what the badge looks like, and if you click it there's a description of how it's calculated:

[![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=uglifier&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=uglifier&package-manager=bundler&version-scheme=semver)