### PR TITLE
change default ie8 support to false

### DIFF
--- a/lib/uglifier.rb
+++ b/lib/uglifier.rb
@@ -96,7 +96,7 @@ class Uglifier
     :define => {}, # Define values for symbol replacement
     :keep_fnames => false, # Generate code safe for the poor souls relying on Function.prototype.name at run-time. Sets both compress and mangle keep_fanems to true.
     :toplevel => false,
-    :ie8 => true, # Generate safe code for IE8
+    :ie8 => false, # Generate safe code for IE8
     :source_map => false, # Generate source map
     :harmony => false # Enable ES6/Harmony mode (experimental). Disabling mangling and compressing is recommended with Harmony mode.
   }

--- a/spec/uglifier_spec.rb
+++ b/spec/uglifier_spec.rb
@@ -294,8 +294,12 @@ describe "Uglifier" do
   describe "ie8 option" do
     let(:code) { "function something() { return g.switch; }" }
 
-    it "defaults to IE8-safe output" do
-      expect(Uglifier.compile(code)).to match("\"switch\"")
+    it "defaults to non-IE8-safe output" do
+      expect(Uglifier.compile(code)).to match(/g\.switch/)
+    end
+
+    it "handles IE8-safe output" do
+      expect(Uglifier.compile(code, :ie8 => true)).to match("\"switch\"")
     end
 
     it "forwards ie8 option to UglifyJS" do
@@ -324,7 +328,7 @@ describe "Uglifier" do
 
   it "quotes unsafe keys by default" do
     code = 'var code = {"class": "", "\u200c":"A"}'
-    expect(Uglifier.compile(code)).to include('"class"')
+    expect(Uglifier.compile(code)).to include('class')
     expect(Uglifier.compile(code)).to include('"\u200c"')
 
     uglifier = Uglifier.new(:output => { :ascii_only => false, :quote_keys => false })


### PR DESCRIPTION
I don't think it's necessary to support ie8 by default these days, see ticket https://github.com/mishoo/UglifyJS2/issues/3211