### PR TITLE
Run Rubocop with GitHub Actions

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,9 @@
+workflow "Lint" {
+  resolves = ["Rubocop"]
+  on = "push"
+}
+
+action "Rubocop" {
+  uses = "lautis/rubocop-action@master"
+  secrets = ["GITHUB_TOKEN"]
+}


### PR DESCRIPTION
Run Rubocop with GitHub Actions. This uses the checks API to report violations, which is easier to read than Travis CI output.