### PR TITLE
Added context sources line to error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Available options and their defaults are
     :output_filename => nil,    # The filename or URL where the minified output can be found
     :input_source_map => nil    # The contents of the source map describing the input
   },
+  :error_context_lines => 8,    # How many context lines surrounding the error line. Env var ERROR_CONTEXT_LINES overrides this option
   :harmony => false             # Enable ES6/Harmony mode (experimental). Disabling mangling and compressing is recommended with Harmony mode.
 }
 ```

--- a/spec/uglifier_spec.rb
+++ b/spec/uglifier_spec.rb
@@ -720,4 +720,65 @@ describe "Uglifier" do
       expect(compiled).to include('baz()')
     end
   end
+
+  describe 'context_source_lines' do
+    let(:code) do
+      <<-JS
+        var foo = { //_1
+          // `foo.bar` should cause panic because with `harmony: false`
+          bar() { //_3
+            console.log('correct es5 syntax:',
+              js` //_5
+              var foo = {
+                bar: function() { //_7
+                  console.log('this is correct es5 syntax')
+                } //_9
+              }
+              ` //_11
+            );
+          }, //_13
+
+          // `foo.baz` ends with `;` which is a syntax error
+          baz: () => { //_16
+            console.log('foo.baz is incorrect');
+          }; //_18
+          //extra line
+        } //_20
+        // end
+      JS
+    end
+
+    it 'contains harmony error message and follows error_context_lines option' do
+      ENV['ERROR_CONTEXT_LINES'] = nil
+      expect { Uglifier.compile(code, :harmony => false, :error_context_lines => 4) }
+        .to raise_error(Uglifier::Error, %r{
+          harmony\smode [^\n]+ Uglifier\.new  # harmony error mesage
+          .+ --\n [^\n]+ //_1\n               # 1 should be the first line
+          .+ => [^\n]+ bar \e\[\d+m \(\)      # should point to () at line 3
+          .+ //_7\n ==\z                      # 7 should be the last line
+        }xm)
+    end
+
+    it 'follows ENV.ERROR_CONTEXT_LINES instead of error_context_lines option' do
+      ENV['ERROR_CONTEXT_LINES'] = '2'
+      expect { Uglifier.compile(code, :harmony => false, :error_context_lines => 4) }
+        .to raise_error(Uglifier::Error, %r{
+          harmony\smode [^\n]+ Uglifier\.new  # harmony error mesage
+          .+ --\n [^\n]+ //_1\n               # 1 should be the first line
+          .+ => [^\n]+ bar \e\[\d+m \(\)      # should point to () at line 3
+          .+ //_5\n ==\z                      # 5 should be the last line
+        }xm)
+    end
+
+    it 'shows lines surrounded syntax error when harmony mode is on' do
+      ENV['ERROR_CONTEXT_LINES'] = '2'
+      expect { Uglifier.compile(code, :harmony => true) }
+        .to raise_error(Uglifier::Error, %r{
+          Unexpect[^\n]+ ; [^\n]+expect [^\n]+ ,  # syntax error mesage
+          .+ --\n [^\n]+ //_16\n                  # 16 should be the first line
+          .+ => [^\n]+ \} \e\[\d+m ;              # should point to ; at line 18
+          .+ //_20\n ==\z                         # 20 should be the last line
+        }xm)
+    end
+  end
 end


### PR DESCRIPTION
this PR is similar to #159 

1. Option `error_context_lines` can be overridden by `ERROR_CONTEXT_LINES`
2. Added 3 test cases
3. Updated README
4. Follows `rubocop` rules.
