### PR TITLE
Fix a result of ["ok", {"error": []}] failed, when it was clearly OK

### DIFF
--- a/lib/uglifier.rb
+++ b/lib/uglifier.rb
@@ -231,12 +231,12 @@ class Uglifier
   end
 
   def parse_result(result, generate_map)
-    raise Error, error_message(result) if result.has_key?('error')
+    raise Error, error_message(result) if result.has_key?('error') && result['error'].respond_to?(:any?) && result['error'].any?
 
     if generate_map
       [result['code'] + source_map_comments, result['map']]
     else
-      result['code'] + source_map_comments
+      (result['code'] || "") + source_map_comments
     end
   end
 


### PR DESCRIPTION
We upgraded Rails from 6.0.3.7 to 6.1.4.

We were receiving errors with no error message: "Uglifier::Error: ".

When I debugged the issue, I was able to find the following:

```
[211, 220] in vendor/bundle/ruby/2.7.0/gems/execjs-2.8.1/lib/execjs/external_runtime.rb
   211:         def exec_runtime(filename)
   212:           io = IO.popen(binary.split(' ') << filename, **(@popen_options.merge({err: [:child, :out]})))
   213:           output = io.read
   214:           io.close
   215:
=> 216:           if $?.success?
   217:             output
   218:           else
   219:             raise exec_runtime_error(output)
   220:           end
(byebug) #<Process::Status: pid 3561 exit 0>
```

Clearly, the output meant "all is OK", but Uglifier didn't treat it as such. I applied this patch in an effort to mitigate the issue for now.

Happy to discuss improvements I can apply to get this, or something similar, merged.